### PR TITLE
Add more clock choices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,3 +272,27 @@ impl Drop for TimerFd {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate libc;
+    use super::ClockId;
+    use super::TimerFd;
+    use super::TimerState;
+
+    #[test]
+    fn new_custom_clockid () {
+
+        fn __test_clockid (clockid: ClockId) {
+            let tfd = TimerFd::new_custom(clockid, true, false).unwrap();
+            assert_eq!(tfd.get_state(), TimerState::Disarmed);
+        }
+
+        __test_clockid(ClockId::Realtime);
+        __test_clockid(ClockId::Monotonic);
+        __test_clockid(ClockId::Boottime);
+        //__test_clockid(ClockId::RealtimeAlarm); // requires CAP_WAKE_ALARM
+        //__test_clockid(ClockId::BoottimeAlarm); // requires CAP_WAKE_ALARM
+    }
+}
+

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -30,8 +30,8 @@ const TS_NULL: timespec = timespec { tv_sec: 0, tv_nsec: 0 };
 impl From<Duration> for timespec {
     fn from(d: Duration) -> timespec {
         timespec {
-            tv_sec: d.as_secs() as i64,
-            tv_nsec: d.subsec_nanos() as i64, // XXX BUG
+            tv_sec: d.as_secs() as libc::time_t,
+            tv_nsec: d.subsec_nanos() as libc::c_long, // XXX BUG
         }
     }
 }


### PR DESCRIPTION
Add support for

       CLOCK_BOOTTIME
       CLOCK_REALTIME_ALARM
       CLOCK_BOOTTIME_ALARM

by introducing an enum for specifying the clock. Includes convenience
printers.