### PR TITLE
Implement FromRawFd for TimerFd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,12 @@ impl AsRawFd for TimerFd {
     }
 }
 
+impl FromRawFd for TimerFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        TimerFd(fd)
+    }
+}
+
 impl Drop for TimerFd {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
In some cases, it's need to construct a timerfd object from an existing
raw fd, so implement FromRawFd trait for TimerFd.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>