### PR TITLE
Use libc constants for flags where available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,9 @@ pub enum SetTimeFlags {
     TimerCancelOnSet,
 }
 
-static TFD_CLOEXEC: libc::c_int = 0o2000000;
-static TFD_NONBLOCK: libc::c_int = 0o0004000;
-static TFD_TIMER_ABSTIME: libc::c_int = 0o0000001;
+static TFD_CLOEXEC: libc::c_int = libc::O_CLOEXEC;
+static TFD_NONBLOCK: libc::c_int = libc::O_NONBLOCK;
+static TFD_TIMER_ABSTIME: libc::c_int = libc::TIMER_ABSTIME;
 static TFD_TIMER_CANCEL_ON_SET: libc::c_int = 0o0000002;
 
 mod structs;


### PR DESCRIPTION
The tests fail on mipsel and mips64el for Debian due to hard-coded values that differ on these architectures. Using the values from the `libc` crate fixes the tests. I'm not sure whether there is a representation of the `TFD_TIMER_CANCEL_ON_SET` flag, so I left it as-is.
Log of a failed mips64el test run: https://buildd.debian.org/status/fetch.php?pkg=rust-timerfd&arch=mips64el&ver=1.0.0-3&stamp=1579871060&raw=0