### PR TITLE
Make read take non-mutable reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ impl TimerFd {
     /// Returns the number of timer expirations since the last read.
     /// If this timerfd is operating in blocking mode (the default), it will
     /// not return zero but instead block until the timer has expired at least once.
-    pub fn read(&mut self) -> u64 {
+    pub fn read(&self) -> u64 {
         const BUFSIZE: usize = 8;
         
         let mut buffer: u64 = 0;


### PR DESCRIPTION
Taking mutable reference makes `TimerFd` unusable with
`tokio::io::unix::AsyncFd` (recently introduced in tokio 0.4).
See https://github.com/tokio-rs/tokio/issues/3068#issuecomment-725516317

All std types based on file descriptors, like `File` and `TcpStream`,
actually take non-mutable references in their read/write methods as well.