### PR TITLE
Update to rustix 0.35.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ version = "1.2.0"
 authors = ["main() <main@ehvag.de>"]
 
 [dependencies]
-rustix = "0.34.2"
+rustix = { version = "0.35.6", features = ["time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,8 +229,8 @@ impl TimerFd {
                     assert_ne!(value, 0);
                     return value;
                 }
-                Err(rustix::io::Error::WOULDBLOCK) => return 0,
-                Err(rustix::io::Error::INTR) => (),
+                Err(rustix::io::Errno::WOULDBLOCK) => return 0,
+                Err(rustix::io::Errno::INTR) => (),
                 Err(e) => panic!("Unexpected read error: {}", e),
                 _ => unreachable!(),
             }


### PR DESCRIPTION
This makes `cargo build` from a clean rust-timerfd tree about 10% faster.