### PR TITLE
Update to rustix 0.36.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ version = "1.2.0"
 authors = ["main() <main@ehvag.de>"]
 
 [dependencies]
-rustix = { version = "0.35.6", features = ["time"] }
+rustix = { version = "0.36.0", features = ["time"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ pub enum TimerState {
 /// See also [`timerfd_create(2)`].
 ///
 /// [`timerfd_create(2)`]: http://man7.org/linux/man-pages/man2/timerfd_create.2.html
-pub struct TimerFd(rustix::io::OwnedFd);
+pub struct TimerFd(rustix::fd::OwnedFd);
 
 impl TimerFd {
     /// Creates a new `TimerFd`.


### PR DESCRIPTION
The main change in rustix 0.36 is to switch to the I/O safety types like `OwnedFd` etc. in std, when available.
