### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! timer implementation is that it implements the `AsRawFd` trait.
 //!
 //! The file descriptor becomes ready/readable whenever the timer expires.
-
+#![warn(missing_debug_implementations)]
 
 extern crate rustix;
 
@@ -151,6 +151,7 @@ pub enum TimerState {
 /// See also [`timerfd_create(2)`].
 ///
 /// [`timerfd_create(2)`]: http://man7.org/linux/man-pages/man2/timerfd_create.2.html
+#[derive(Debug)]
 pub struct TimerFd(rustix::fd::OwnedFd);
 
 impl TimerFd {


### PR DESCRIPTION
Sets `missing_debug_implementations` to warn and adds missing `std::fmt::Debug` implementations.

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.