### PR TITLE
Update to rustix 0.38.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ version = "1.5.0"
 authors = ["main() <main@ehvag.de>"]
 
 [dependencies]
-rustix = { version = "0.37.0", features = ["time"] }
+rustix = { version = "0.38.0", features = ["time"] }


### PR DESCRIPTION
timerfd doesn't need any code changes to update to rustix 0.37.