### PR TITLE
Use no-default-features for rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,8 @@ license = "MIT"
 version = "1.5.0"
 authors = ["main() <main@ehvag.de>"]
 
-[dependencies]
-rustix = { version = "0.38.0", features = ["time"] }
+[dependencies.rustix]
+version = "0.38.0"
+default-features = false
+features = ["std", "time"]
+


### PR DESCRIPTION
This prevents rustix from bringing in libc for auxv checks, which this crate does not use.
